### PR TITLE
Using environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+API_ID=
+API_HASH=

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 _*
-.*
+.env
 *.txt
 *.csv
 !requirements.txt
 test*
-appconfig.py

--- a/README.md
+++ b/README.md
@@ -5,21 +5,24 @@
 
 ## Telegram Analysis
 
-***Steps:***
+**_Steps:_**
+
 1. Go to [Telegram Apps](https://my.telegram.org/auth?to=apps) to get **_api_id_** and **_api_hash_**
 
-2. Clone repo by ```git clone https://github.com/mzarchi/telegram.git```
+2. Clone repo by `git clone https://github.com/mzarchi/telegram.git`
 
-3. Install lib by ```pip install -r requirements.txt```
+3. Install lib by `pip install -r requirements.txt`
 
-4. Rename ```/config/appconfig_ignore.py``` to ```/config/appconfig.py``` and put your **_api_id_** and **_api_hash_**
-    > <sub>At this step, you must have **api_id** and **api_hash**</sub>
+4. Copy `.env.example` to `.env` and put your **_api_id_** and **_api_hash_** with `cp .env.example .env`
 
-5. Login to your **Telegram** account by ```/login/main.py``` and save **automatically** your session in ```/sessions```
+   > <sub>At this step, you must have **api_id** and **api_hash**</sub>
 
-6. Open ```/channel/analysis.ipynb``` and run first cell
+5. Login to your **Telegram** account by `/login/main.py` and save **automatically** your session in `/sessions`
 
-## Supported params in ```/channel/analysis.ipynb```
+6. Open `/channel/analysis.ipynb` and run first cell
+
+## Supported params in `/channel/analysis.ipynb`
+
 The most important cell in this notebook is this:
 
 ```
@@ -36,7 +39,8 @@ dics = cdata(
 )
 ```
 
-According to the following ```match_case```:
+According to the following `match_case`:
+
 ```
 0 : No limit *
 1 : DateTime limit *
@@ -56,4 +60,5 @@ According to the following ```match_case```:
 46 : Forward & ID limit *
 56 : Mention & ID limit *
 ```
+
 You can get the data you want in an edited form!

--- a/config/appconfig.py
+++ b/config/appconfig.py
@@ -1,0 +1,14 @@
+# Using dotenv to use environment variables
+from dotenv import load_dotenv
+import os
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Access environment variables
+env = os.environ
+
+timezone = 'Asia/Tehran'
+
+api_id = env["API_ID"]
+api_hash = env["API_HASH"]

--- a/config/appconfig.py.example
+++ b/config/appconfig.py.example
@@ -1,4 +1,0 @@
-# Rename this file to appconfig.py
-timezone = 'Asia/Tehran'
-api_id = 0
-api_hash = "Null"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytz
 telethon
 colorama
+python-dotenv


### PR DESCRIPTION
## Summary

You can use **environment variables** instead of renaming config file.

## Change logs

- Using **env** in `appconfig.py`.
- Add `python-dotenv` librrary.
- Add `.env.example` file that is an example that user have to config.
- Update `.gitignore` for ignoring `.env` and not that python config file.
- Update `README.md` for configuration.

---

Amir.